### PR TITLE
Clarifying the visual of MatchParen.

### DIFF
--- a/colors/kuroi.vim
+++ b/colors/kuroi.vim
@@ -229,7 +229,7 @@ exe "hi! SignColumn"    .s:fg_none        .s:bg_background  .s:fmt_none
 "   Incsearch"
 exe "hi! LineNr"        .s:fg_selection   .s:bg_none        .s:fmt_none
 exe "hi! CursorLineNr"  .s:fg_yellow      .s:bg_none        .s:fmt_none
-exe "hi! MatchParen"    .s:fg_background  .s:bg_changebg    .s:fmt_none
+exe "hi! MatchParen"    .s:fg_none        .s:bg_changebg    .s:fmt_none
 exe "hi! ModeMsg"       .s:fg_green       .s:bg_none        .s:fmt_none
 exe "hi! MoreMsg"       .s:fg_green       .s:bg_none        .s:fmt_none
 exe "hi! NonText"       .s:fg_selection   .s:bg_none        .s:fmt_none


### PR DESCRIPTION
This clarifies the color patterns of the matched parentheses.
Consider these examples, where the cursor is positioned over the leftmost parentheses:

![image](https://user-images.githubusercontent.com/27740271/59406859-e691ea80-8d85-11e9-8ca5-304b6e4c888e.png)
The current state does not make much sense as this highlights the corresponding parenthesis more than the cursor.

![image](https://user-images.githubusercontent.com/27740271/59406894-fb6e7e00-8d85-11e9-8374-5118da3ac2cf.png)
I personally think this way it is clearer to identify where the cursor is located.

Thanks for listening!