### PR TITLE
Deleted EndOfBuffer assignment for EoB color cross-terminal emulators

### DIFF
--- a/colors/kuroi.vim
+++ b/colors/kuroi.vim
@@ -250,7 +250,6 @@ exe "hi! StatusLineTerm"    .s:fg_gray        .s:bg_statusline    .s:fmt_revr
 exe "hi! StatusLineTermNC"  .s:fg_gray        .s:bg_statuslinenc  .s:fmt_revr
 exe "hi! TabLine"           .s:fg_foreground  .s:bg_darkcolumn    .s:fmt_revr
 exe "hi! TabLineFill"       .s:fg_background  .s:bg_background    .s:fmt_revr
-exe "hi! EndOfBuffer"       .s:fg_background  .s:bg_background    .s:fmt_revr
 "   TabLineSel"
 exe "hi! Title"             .s:fg_yellow      .s:bg_none        .s:fmt_none
 exe "hi! Visual"            .s:fg_none        .s:bg_selection   .s:fmt_none


### PR DESCRIPTION
Depending on the terminal emulator, EndOfBuffer could show as the light rather than the (presumably?) expected dark color on non-EndOfBuffer lines.

![https://i.imgur.com/viFEXvs.png](https://i.imgur.com/viFEXvs.png)
The link shows six splits, with the problematic one being the one in the top-middle.
```text
xterm w/ EndOfBuffer  | alacritty w/ EndOfBuffer  | source code
xterm w/o EndOfBuffer | alacritty w/o EndOfBuffer | EndOfBuffer help
```
Other colorschemes (among those I checked) does not seem to assign EndOfBuffer.
checked: corporation, Monokai, solarized-dark

Not sure what was intended with the assignment, so feel free to reject the PR of course.
I'd love to learn when EndOfBuffer should be assigned if so!

Did not confirm with gvim.
Did confirm white bg with minimal-ish vimrc (includes vim-plug) on arch with i3-wm and alacritty
```vim
set runtimepath^=~/.vim/
call plug#begin('~/.vim/plugged')
    Plug 'aonemd/kuroi.vim'
call plug#end()
colorscheme kuroi
```